### PR TITLE
Update dependency: meilisearch js library

### DIFF
--- a/packages/medusa-plugin-meilisearch/package.json
+++ b/packages/medusa-plugin-meilisearch/package.json
@@ -22,7 +22,7 @@
     "@medusajs/utils": "1.8.1",
     "body-parser": "^1.19.0",
     "lodash": "^4.17.21",
-    "meilisearch": "^0.31.1"
+    "meilisearch": "^0.32.3"
   },
   "devDependencies": {
     "@medusajs/medusa": "1.8.2",


### PR DESCRIPTION
This change updates the meilisearch library dependency to be compatible with meilisearch 1.0+.  This fixes issues recently reported in the Medusa Discord that are caused by using newer versions of meilisearch.

https://discord.com/channels/876835651130097704/1098015733822267392
